### PR TITLE
docs: add conventional commits adr and workflow

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,42 @@
+{
+    "extends": [
+        "@commitlint/config-conventional"
+    ],
+    "rules": {
+        "type-enum": [
+            2,
+            "always",
+            [
+                "build",
+                "chore",
+                "ci",
+                "docs",
+                "feat",
+                "fix",
+                "perf",
+                "refactor",
+                "revert",
+                "style",
+                "test"
+            ]
+        ],
+        "subject-case": [
+            2,
+            "always",
+            [
+                "sentence-case",
+                "lower-case"
+            ]
+        ],
+        "body-max-line-length": [
+            2,
+            "always",
+            100
+        ],
+        "subject-full-stop": [
+            2,
+            "never",
+            "."
+        ]
+    }
+}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,21 @@
+name: Validate Conventional Commits
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          
+      - name: Validate all commits
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.json
+          failOnWarnings: true 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to the Deployment System
+
+Thank you for your interest in contributing to our deployment system! This document provides guidelines and instructions for contributing.
+
+## Pull Request Process
+
+1. All changes must be made through pull requests - no direct commits to the main branch
+2. Pull requests require at least one reviewer approval before merging
+3. Branch names should follow the format: `<type>/<description>` (e.g., `feat/add-canary-deployments`)
+4. Ensure your code passes all automated tests
+5. Update documentation as necessary
+
+## Conventional Commits
+
+This project strictly follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. All commit messages must adhere to this format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, semicolons, etc.; no code change)
+- `refactor`: Code changes that neither fix bugs nor add features
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `build`: Changes to build system or dependencies
+- `ci`: Changes to CI configuration files and scripts
+- `chore`: Routine tasks, maintenance, etc.
+- `revert`: Reverting a previous commit
+
+### Scopes
+
+Scopes are optional but encouraged. They provide additional contextual information about the change. Example scopes for this project include:
+
+- `api`: Changes to the API
+- `agent`: Changes to deployment agents
+- `orchestrator`: Changes to the orchestrator
+- `config`: Changes to configuration handling
+- `security`: Security-related changes
+- `docs`: Documentation changes
+
+### Examples
+
+```
+feat(api): add new endpoint for deployment status
+
+Added a new REST endpoint that allows clients to query the status of a deployment.
+```
+
+```
+fix(agent): resolve connection timeout issue
+
+Increased the connection timeout to prevent agents from disconnecting prematurely.
+
+Resolves #123
+```
+
+```
+chore: update dependencies to latest versions
+```
+
+```
+feat!: change authentication flow
+
+BREAKING CHANGE: The authentication workflow has been completely redesigned.
+Clients need to update their integration to use the new OAuth flow.
+```
+
+## Semantic Versioning
+
+Commit types automatically determine how version numbers are incremented:
+
+- `fix` type commits trigger a PATCH version increment (1.0.x)
+- `feat` type commits trigger a MINOR version increment (1.x.0)
+- Commits with `BREAKING CHANGE:` in the footer or with `!` after the type/scope trigger a MAJOR version increment (x.0.0)
+
+## Development Workflow
+
+1. Create a new branch from `main`
+2. Make your changes with conventional commits
+3. Push your branch and create a pull request
+4. Address any feedback from reviewers
+5. Once approved, your PR will be merged
+
+## Code Style and Quality
+
+- Follow the established code style in the project
+- Write unit tests for new features and bug fixes
+- Ensure your code passes linting and tests before submitting a PR 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ This project is currently in the planning phase. Implementation will begin once 
 
 Contributions are welcome! Please read the [contributing guidelines](CONTRIBUTING.md) before submitting a pull request.
 
+### Commit Guidelines
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/) to automate versioning and changelog generation. All commits must follow this format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Types include:
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, etc)
+- `refactor`: Code changes that neither fix bugs nor add features
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `chore`: Routine tasks, maintenance, etc.
+
+Breaking changes must be indicated with `!` or `BREAKING CHANGE:` in the footer.
+
 ## License
 
 [MIT](LICENSE) 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,8 +32,7 @@ Each ADR follows this template:
 ## ADR Index
 
 - [ADR-0001: Record Architecture Decisions](adr-0001-record-architecture-decisions.md)
-- [ADR-0002: TBD](adr-0002-tbd.md)
-```
+- [ADR-0002: Use Conventional Commits](adr-0002-conventional-commits.md)
 
 ## How to Create a New ADR
 

--- a/docs/decisions/adr-0002-conventional-commits.md
+++ b/docs/decisions/adr-0002-conventional-commits.md
@@ -1,0 +1,47 @@
+# ADR-0002: Use Conventional Commits
+
+## Status
+Proposed
+
+## Context
+As our deployment system grows, we need a standardized commit message structure to:
+- Provide clear commit history that's human and machine-readable
+- Automate versioning and changelog generation
+- Enforce quality commit messages
+- Streamline the release process
+
+Without standardized commit messages, it becomes difficult to track what types of changes are being made and to automate version increments.
+
+## Decision
+We will adopt the Conventional Commits specification (https://www.conventionalcommits.org/) for all commit messages in this repository.
+
+Key aspects of this decision:
+- All commits must follow the Conventional Commits format:
+  ```
+  <type>[optional scope]: <description>
+  
+  [optional body]
+  
+  [optional footer(s)]
+  ```
+- All commits must be submitted via pull requests, including this ADR
+- A GitHub workflow will be implemented to validate commits against the conventional format
+- Semantic versioning will be automatically enforced based on commit types:
+  - `fix:` - Patch version (1.0.x)
+  - `feat:` - Minor version (1.x.0)
+  - Breaking changes (indicated by `!` or `BREAKING CHANGE:` in footer) - Major version (x.0.0)
+
+## Consequences
+- Developers must learn and follow the Conventional Commits specification
+- Pull requests that don't adhere to the format will be rejected automatically
+- Release versioning will become more consistent and automated
+- Changelog generation can be automated
+- Better visibility into the types of changes being made
+- Easier for new team members to understand the impact of historical changes
+- Pull requests become mandatory for all changes, enforcing code review
+
+## Compliance
+- All developers must follow the Conventional Commits specification
+- The GitHub workflow must be kept functional and not bypassed
+- Pull requests are required for all changes
+- Regular audits should ensure compliance with the commit format 


### PR DESCRIPTION
This PR adds: ADR-0002 documenting the decision to use conventional commits, GitHub workflow to enforce conventional commits format, CommitLint configuration, and updated documentation with commit guidelines in README and CONTRIBUTING.md. This will enforce semantic versioning through conventional commit messages and ensure consistent commit history.