### PR TITLE
docs: add open source licensing adr and license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3
+with COMMONS CLAUSE
+
+All rights to the Deployment System are licensed under the terms of the GNU Affero General Public License version 3 (AGPL-3.0) as published by the Free Software Foundation, with the additional restrictions of the Commons Clause.
+
+The full text of the AGPL-3.0 can be found at: https://www.gnu.org/licenses/agpl-3.0.en.html
+
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+For purposes of this license:
+- "Software" means the Deployment System software
+- "Licensor" means the owners and contributors to the Deployment System
+- "License" means the AGPL-3.0
+
+This license applies to all parts of the Deployment System that are not externally maintained libraries. 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,8 +32,8 @@ Each ADR follows this template:
 ## ADR Index
 
 - [ADR-0001: Record Architecture Decisions](adr-0001-record-architecture-decisions.md)
-- [ADR-0002: TBD](adr-0002-tbd.md)
-```
+- [ADR-0002: Use Conventional Commits](adr-0002-conventional-commits.md)
+- [ADR-0003: Open Source Licensing Model](adr-0003-open-source-license.md)
 
 ## How to Create a New ADR
 

--- a/docs/decisions/adr-0003-open-source-license.md
+++ b/docs/decisions/adr-0003-open-source-license.md
@@ -1,0 +1,40 @@
+# ADR-0003: Open Source Licensing Model
+
+## Status
+Proposed
+
+## Context
+The deployment system has potential value to the broader technical community. Open-sourcing the project would allow others to use, contribute to, and improve the system. However, we want to prevent commercial entities from using our codebase to create competing commercial products without contributing back.
+
+We need a licensing model that:
+- Allows users to freely use the software
+- Encourages contributions from the community
+- Ensures modifications are shared back with the community
+- Prevents commercial products from being built using our codebase
+
+## Decision
+We will adopt the GNU Affero General Public License version 3 (AGPL-3.0) with the addition of the Commons Clause.
+
+Key aspects of this decision:
+- The AGPL-3.0 is a strong copyleft license that requires any modified versions to be open-sourced, even when used to provide a service over a network
+- The Commons Clause will be added to explicitly prohibit using the software commercially to sell a product or service
+- All source code will be publicly available on GitHub
+- External contributions will be welcome through pull requests
+- All contributions must adhere to the same license terms
+
+Note: This combination (AGPL + Commons Clause) means the project is technically "source-available" rather than "open source" as defined by the Open Source Initiative, as the Commons Clause restricts commercial use.
+
+## Consequences
+- The community can use and contribute to the project
+- All improvements to the code must be shared with everyone
+- Commercial companies cannot create closed-source products from our code
+- Commercial companies cannot sell services based directly on our code
+- We may receive reduced contributions from commercial entities
+- We will need to maintain contributor agreements
+- We may need to address licensing questions from potential users
+
+## Compliance
+- All code files must include appropriate license headers
+- The repository must include full license text
+- Contributors must sign a Contributor License Agreement
+- We must periodically review the licensing model to ensure it continues to meet our needs 


### PR DESCRIPTION
This PR adds: ADR-0003 proposing AGPL with Commons Clause as our licensing model and adds the corresponding LICENSE file. This approach allows free use and modification while preventing commercial exploitation of our codebase.