### PR TITLE
docs: add programming language and framework selection adr

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,8 +32,9 @@ Each ADR follows this template:
 ## ADR Index
 
 - [ADR-0001: Record Architecture Decisions](adr-0001-record-architecture-decisions.md)
-- [ADR-0002: TBD](adr-0002-tbd.md)
-```
+- [ADR-0002: Use Conventional Commits](adr-0002-conventional-commits.md)
+- [ADR-0003: Open Source Licensing Model](adr-0003-open-source-license.md)
+- [ADR-0004: Programming Language and Framework Selection](adr-0004-programming-language-and-framework.md)
 
 ## How to Create a New ADR
 

--- a/docs/decisions/adr-0004-programming-language-and-framework.md
+++ b/docs/decisions/adr-0004-programming-language-and-framework.md
@@ -1,0 +1,114 @@
+# ADR-0004: Programming Language and Framework Selection
+
+## Status
+Proposed
+
+## Context
+The deployment system needs a robust, scalable foundation that can handle complex deployment operations, concurrent tasks, and system-level interactions. The choice of programming language and framework will significantly impact development speed, operational characteristics, and long-term maintainability.
+
+Key requirements:
+- High performance for concurrent operations
+- Strong system-level programming capabilities
+- Rich ecosystem for deployment-related tools
+- Good developer experience
+- Strong security features
+- Cross-platform compatibility
+- Active community and long-term support
+
+## Decision
+We will use **Rust** as our primary programming language with the following key frameworks and libraries:
+
+### Core Framework Stack:
+- **Tokio**: Async runtime for handling concurrent operations
+- **Axum**: Web framework for API development
+- **SQLx**: Database access with compile-time verification
+- **Serde**: Serialization/deserialization
+- **Tracing**: Observability and logging
+- **Clap**: Command-line argument parsing
+
+### Rationale for Rust:
+1. **Performance & Safety**
+   - Zero-cost abstractions
+   - Memory safety without garbage collection
+   - Thread safety guarantees
+   - High performance comparable to C/C++
+
+2. **Ecosystem**
+   - Strong container and deployment libraries
+   - Excellent async support
+   - Rich security-focused crates
+   - Growing cloud provider SDKs
+
+3. **Developer Experience**
+   - Strong type system
+   - Excellent error handling
+   - Great IDE support (rust-analyzer)
+   - Comprehensive testing framework
+   - Clear documentation
+
+4. **Operational Benefits**
+   - Single binary deployment
+   - Minimal runtime dependencies
+   - Excellent cross-platform support
+   - Built-in concurrency safety
+
+5. **Security**
+   - Memory safety by default
+   - Thread safety guarantees
+   - Strong type system prevents many runtime errors
+   - Active security-focused community
+
+6. **Long-term Viability**
+   - Backed by Mozilla and growing industry support
+   - Active community and rapid growth
+   - Strong commitment to stability
+   - Clear upgrade paths
+
+### Alternative Options Considered:
+
+1. **Go**
+   - Pros:
+     - Simple concurrency model
+     - Fast compilation
+     - Good standard library
+   - Cons:
+     - Less type safety
+     - Garbage collection overhead
+     - Fewer compile-time guarantees
+
+2. **Python**
+   - Pros:
+     - Rich ecosystem
+     - Easy to learn
+     - Great for prototyping
+   - Cons:
+     - Performance limitations
+     - Dynamic typing risks
+     - GIL limitations for concurrency
+     - Dependency management complexity
+
+3. **Java/Kotlin**
+   - Pros:
+     - Mature ecosystem
+     - Strong enterprise support
+     - Good performance
+   - Cons:
+     - JVM overhead
+     - Complex deployment
+     - Less suitable for system programming
+
+## Consequences
+- Team members will need to learn Rust if not already familiar
+- Initial development might be slower due to Rust's learning curve
+- Need to carefully manage dependencies and versioning
+- Must establish clear coding standards for Rust
+- Will need to invest in Rust-specific CI/CD tooling
+- May need to write some system-level code in C for specific platforms
+
+## Compliance
+- All new code must be written in Rust
+- External dependencies must be carefully vetted
+- Regular security audits of dependencies required
+- Performance benchmarks must be maintained
+- Documentation must be kept up to date with code changes
+- Regular updates to Rust toolchain and dependencies 


### PR DESCRIPTION
This PR adds ADR-0004 proposing Rust as our primary programming language with a specific framework stack. The ADR evaluates Rust against other options and provides detailed rationale for the choice, including performance, safety, ecosystem, and long-term viability considerations.