### PR TITLE
docs: fix programming language and framework selection adr

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,22 +11,22 @@ An Architecture Decision Record is a document that captures an important archite
 Each ADR follows this template:
 
 ```markdown
-# ADR-NNNN: Title
+# ADR-XXXX: Title
 
 ## Status
-[Proposed | Accepted | Deprecated | Superseded by ADR-XXXX]
+[Proposed | Accepted | Deprecated | Superseded]
 
 ## Context
-[Description of the problem and context]
+[Describe the context and problem statement that led to this decision]
 
 ## Decision
-[Description of the decision]
+[Describe the decision that was made]
 
 ## Consequences
-[Description of the consequences of the decision]
+[Describe the consequences, both positive and negative, of this decision]
 
 ## Compliance
-[Compliance requirements, if any]
+[List the requirements for complying with this decision]
 ```
 
 ## ADR Index
@@ -34,12 +34,12 @@ Each ADR follows this template:
 - [ADR-0001: Record Architecture Decisions](adr-0001-record-architecture-decisions.md)
 - [ADR-0002: Use Conventional Commits](adr-0002-conventional-commits.md)
 - [ADR-0003: Open Source Licensing Model](adr-0003-open-source-license.md)
-
-=======
+- [ADR-0004: Programming Language and Framework Selection](adr-0004-programming-language-and-framework.md)
 
 ## How to Create a New ADR
 
-1. Create a new file in this directory with the name `adr-NNNN-title.md`, where `NNNN` is the next available ADR number and `title` is a short hyphenated name.
-2. Copy the template above and fill in the details.
-3. Add the new ADR to the index in this README.
-4. Submit the ADR for review and approval. 
+1. Create a new file named `adr-XXXX-title.md` in this directory
+2. Copy the template above into the new file
+3. Fill in the details following the template
+4. Update this README.md to include the new ADR in the index
+5. Create a pull request with your changes 

--- a/docs/decisions/adr-0004-programming-language-and-framework.md
+++ b/docs/decisions/adr-0004-programming-language-and-framework.md
@@ -1,0 +1,137 @@
+# ADR-0004: Programming Language and Framework Selection
+
+## Status
+Proposed
+
+## Context
+The deployment system needs to be built with a programming language and framework that can handle complex operations, system-level interactions, and provide robust performance. The choice of programming language and framework will significantly impact development speed, maintainability, and the system's ability to meet its requirements.
+
+## Key Requirements
+- High performance for concurrent operations
+- Strong system-level capabilities
+- Rich ecosystem of libraries
+- Good developer experience
+- Strong security features
+- Cross-platform compatibility
+- Active community and long-term support
+
+## Decision
+We will use **Rust** as our primary programming language with the following core framework stack:
+
+- **Tokio**: Async runtime for concurrent operations
+- **Axum**: Web framework for API development
+- **SQLx**: Database access with compile-time verification
+- **Serde**: Serialization/deserialization
+- **Tracing**: Observability and logging
+- **Clap**: Command-line argument parsing
+
+## Rationale for Rust
+
+### Performance and Safety
+- Zero-cost abstractions
+- Memory safety without garbage collection
+- Thread safety guarantees
+- High performance comparable to C/C++
+- Strong type system preventing runtime errors
+
+### Ecosystem Advantages
+- Excellent package management with Cargo
+- Rich ecosystem for infrastructure tools
+- Strong container and cloud-native support
+- Mature async/await support
+- Excellent FFI capabilities
+
+### Developer Experience
+- Modern tooling and IDE support
+- Clear error messages and compiler guidance
+- Built-in testing framework
+- Documentation generation
+- Strong community support
+
+### Operational Benefits
+- Single binary deployment
+- No runtime dependencies
+- Small memory footprint
+- Excellent monitoring and observability
+- Cross-platform compilation
+
+### Security Features
+- Memory safety by default
+- Thread safety guarantees
+- No undefined behavior
+- Strong type system
+- Built-in security best practices
+
+### Long-term Viability
+- Backed by Mozilla and growing community
+- Used in production by major companies
+- Regular updates and improvements
+- Strong backward compatibility
+- Clear upgrade paths
+
+## Alternative Options Considered
+
+### Go
+Pros:
+- Simple and easy to learn
+- Fast compilation
+- Good standard library
+- Built-in concurrency
+
+Cons:
+- Less type safety
+- Limited generics support
+- Garbage collection overhead
+- Less mature ecosystem for infrastructure tools
+
+### Python
+Pros:
+- Easy to learn and use
+- Rich ecosystem
+- Rapid development
+- Great for prototyping
+
+Cons:
+- Performance limitations
+- Dynamic typing risks
+- GIL limitations
+- Deployment complexity
+- Memory usage
+
+### Java/Kotlin
+Pros:
+- Mature ecosystem
+- Strong type system
+- Good performance
+- Enterprise-ready
+
+Cons:
+- JVM overhead
+- Larger memory footprint
+- Slower startup time
+- More complex deployment
+- Less suitable for system-level operations
+
+## Consequences
+
+### Positive
+- High performance and reliability
+- Strong safety guarantees
+- Excellent developer experience
+- Future-proof technology choice
+- Strong community support
+
+### Negative
+- Learning curve for team members
+- Initial development may be slower
+- Need to establish coding standards
+- Need to set up CI/CD tooling
+- May need to hire Rust developers
+
+## Compliance
+- All new code must be written in Rust
+- Dependencies must be managed through Cargo
+- Regular security audits of dependencies
+- Performance benchmarks for critical paths
+- Documentation must be kept up to date
+- Code must follow Rust best practices 


### PR DESCRIPTION
This PR fixes the empty ADR-0004 file and resolves merge conflicts in README.md. The ADR now properly documents our decision to use Rust as the primary programming language with a core framework stack including Tokio, Axum, SQLx, Serde, Tracing, and Clap.