### PR TITLE
docs: add frontend architecture adr and update backend adr

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -35,6 +35,7 @@ Each ADR follows this template:
 - [ADR-0002: Use Conventional Commits](adr-0002-conventional-commits.md)
 - [ADR-0003: Open Source Licensing Model](adr-0003-open-source-license.md)
 - [ADR-0004: Programming Language and Framework Selection](adr-0004-programming-language-and-framework.md)
+- [ADR-0005: Frontend Architecture Selection](adr-0005-frontend-architecture.md)
 
 ## How to Create a New ADR
 

--- a/docs/decisions/adr-0004-programming-language-and-framework.md
+++ b/docs/decisions/adr-0004-programming-language-and-framework.md
@@ -16,7 +16,7 @@ The deployment system needs to be built with a programming language and framewor
 - Active community and long-term support
 
 ## Decision
-We will use **Rust** as our primary programming language with the following core framework stack:
+We will use **Rust** as our primary programming language for backend components with the following core framework stack:
 
 - **Tokio**: Async runtime for concurrent operations
 - **Axum**: Web framework for API development
@@ -24,6 +24,8 @@ We will use **Rust** as our primary programming language with the following core
 - **Serde**: Serialization/deserialization
 - **Tracing**: Observability and logging
 - **Clap**: Command-line argument parsing
+
+Note: The frontend architecture and technology stack will be addressed in a separate ADR (ADR-0005), as we have decided to adopt a service-oriented architecture with separate frontend and backend services.
 
 ## Rationale for Rust
 
@@ -129,7 +131,7 @@ Cons:
 - May need to hire Rust developers
 
 ## Compliance
-- All new code must be written in Rust
+- All backend code must be written in Rust
 - Dependencies must be managed through Cargo
 - Regular security audits of dependencies
 - Performance benchmarks for critical paths

--- a/docs/decisions/adr-0005-frontend-architecture.md
+++ b/docs/decisions/adr-0005-frontend-architecture.md
@@ -1,0 +1,145 @@
+# ADR-0005: Frontend Architecture Selection
+
+## Status
+Proposed
+
+## Context
+The deployment system requires a user interface for users to:
+- View deployment status in real-time
+- Provide manual approvals
+- View deployment history
+- Configure deployment settings
+- Monitor system health
+
+We need to decide whether to build a modular monolith where Rust handles both backend and frontend, or adopt a service-oriented architecture with separate frontend and backend services.
+
+## Key Requirements
+- Rich, interactive user interface
+- Real-time updates for deployment status
+- Complex forms and data visualization
+- Responsive design
+- Cross-browser compatibility
+- Easy maintenance and updates
+- Efficient development workflow
+- Access to mature UI components and libraries
+
+## Decision
+We will adopt a service-oriented architecture with:
+- Backend services written in Rust (as per ADR-0004)
+- Separate frontend service using TypeScript and React
+- RESTful API communication between services
+- WebSocket for real-time updates
+
+### Frontend Technology Stack
+- **TypeScript**: For type safety and better developer experience
+- **React**: For building interactive user interfaces
+- **Next.js**: For server-side rendering and optimal performance
+- **Tailwind CSS**: For styling and responsive design
+- **React Query**: For efficient data fetching and caching
+- **Socket.io-client**: For real-time updates
+- **React Hook Form**: For form handling
+- **Zod**: For runtime type validation
+
+## Rationale
+
+### Why Service-Oriented Architecture?
+1. **Separation of Concerns**
+   - Backend focuses on deployment logic and system operations
+   - Frontend focuses on user interaction and experience
+   - Each service can evolve independently
+
+2. **Development Efficiency**
+   - Faster UI development with established tools
+   - Parallel development of frontend and backend
+   - Easier to maintain and update each service
+
+3. **Technology Flexibility**
+   - Can leverage best-in-class tools for each domain
+   - Easier to adopt new frontend technologies
+   - Better access to UI components and libraries
+
+4. **Team Organization**
+   - Can hire specialized developers
+   - Clear ownership of components
+   - Easier onboarding for new team members
+
+### Why TypeScript and React?
+1. **TypeScript Benefits**
+   - Type safety and better IDE support
+   - Catch errors at compile time
+   - Better maintainability
+   - Improved developer experience
+
+2. **React Benefits**
+   - Large ecosystem of components
+   - Strong community support
+   - Excellent developer tools
+   - Reusable component architecture
+   - Virtual DOM for performance
+
+3. **Next.js Benefits**
+   - Server-side rendering
+   - API routes
+   - Built-in routing
+   - Optimized performance
+   - Easy deployment
+
+## Alternative Options Considered
+
+### Modular Monolith with Rust Frontend
+Pros:
+- Single codebase and deployment
+- Shared types and business logic
+- Simpler deployment and maintenance
+- No cross-service communication overhead
+- Consistent tooling and development experience
+
+Cons:
+- Rust's web UI ecosystem is less mature
+- Fewer UI components and libraries
+- Harder to hire developers
+- Less flexibility in technology choices
+- Potentially slower UI development
+
+### Vue.js Alternative
+Pros:
+- Lighter weight than React
+- Simpler learning curve
+- Good documentation
+- Strong community
+
+Cons:
+- Smaller ecosystem than React
+- Fewer enterprise-level components
+- Less corporate backing
+- Fewer job candidates
+
+## Consequences
+
+### Positive
+- Faster UI development
+- Better developer experience
+- Access to mature UI ecosystem
+- Easier to hire developers
+- More flexible architecture
+- Better separation of concerns
+
+### Negative
+- More complex deployment
+- Need to handle cross-service communication
+- Potential consistency issues
+- More infrastructure to manage
+- Multiple codebases to maintain
+- Need to establish API contracts
+
+## Compliance
+- Frontend must be written in TypeScript
+- React components must follow functional patterns
+- All API endpoints must be documented
+- Real-time updates must use WebSocket
+- UI must be responsive and accessible
+- Code must follow React best practices
+- TypeScript strict mode must be enabled
+- All components must have unit tests
+- API contracts must be versioned
+- Frontend must handle offline scenarios 


### PR DESCRIPTION
This PR adds ADR-0005 proposing a service-oriented architecture with TypeScript/React frontend, and updates ADR-0004 to clarify Rust's role in backend components. The frontend stack includes TypeScript, React, Next.js, Tailwind CSS, React Query, Socket.io-client, React Hook Form, and Zod.