### PR TITLE
chore: consolidate commitlint configuration

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -33,6 +33,11 @@
             "always",
             100
         ],
+        "header-max-length": [
+            2,
+            "always",
+            72
+        ],
         "subject-full-stop": [
             2,
             "never",


### PR DESCRIPTION
This PR consolidates our commitlint configuration into a single source of truth to ensure consistent behavior between local hooks and CI. Changes: - Removes commitlint.config.js in favor of .commitlintrc.json - Adds header-max-length rule from JS config to JSON config - Maintains all existing rules from both configurations. This change will help prevent situations where commits pass locally but fail in CI due to different rule sets.