### PR TITLE
ci: loosen commitlint rules and change to warning level

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -4,7 +4,7 @@
     ],
     "rules": {
         "type-enum": [
-            2,
+            1,
             "always",
             [
                 "build",
@@ -21,25 +21,29 @@
             ]
         ],
         "subject-case": [
-            2,
+            1,
             "always",
             [
+                "lower-case",
+                "upper-case",
                 "sentence-case",
-                "lower-case"
+                "start-case",
+                "pascal-case",
+                "camel-case"
             ]
         ],
         "body-max-line-length": [
-            2,
+            1,
             "always",
             100
         ],
         "header-max-length": [
-            2,
+            1,
             "always",
             72
         ],
         "subject-full-stop": [
-            2,
+            1,
             "never",
             "."
         ]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-    extends: ['@commitlint/config-conventional'],
-    rules: {
-        'body-max-line-length': [2, 'always', 100],
-        'header-max-length': [2, 'always', 72],
-    },
-}; 


### PR DESCRIPTION
Loosen commitlint rules and change to warning level

Changes made:
- Changed all rule levels from error (2) to warning (1)
- Added more allowed case options for commit messages:
  - lower-case
  - upper-case
  - sentence-case
  - start-case
  - pascal-case
  - camel-case

This change makes the commit message linting less strict while still encouraging good practices through warnings rather than errors.
